### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 django_admin_thumbnail
 ======================
-[![PyPi version](https://pypip.in/v/django_admin_thumbnail/badge.png)](https://crate.io/packages/django_admin_thumbnail/)
-[![PyPi downloads](https://pypip.in/d/django_admin_thumbnail/badge.png)](https://crate.io/packages/django_admin_thumbnail/)
+[![PyPi version](https://img.shields.io/pypi/v/django_admin_thumbnail.svg)](https://crate.io/packages/django_admin_thumbnail/)
+[![PyPi downloads](https://img.shields.io/pypi/dm/django_admin_thumbnail.svg)](https://crate.io/packages/django_admin_thumbnail/)
 
 This is a package developed to help you with `ImageField` visualization in your `ModelAdmin`. It automatically creates user friendly thumbnail for any `ImageField` you choose to put in your `list_display`.
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-admin-thumbnail))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-admin-thumbnail`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.